### PR TITLE
Fix buggy text node validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ Brewfile.lock.json
 
 # uses rye still
 uv.lock
+requirements.lock
+requirements-dev.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Most tests require you to [set up a mock server](https://github.com/stoplightio/
 
 ```sh
 # you will need npm installed
-$ npx prism mock path/to/your/openapi.yml
+$ ./scripts/mock --daemon
 ```
 
 ```sh

--- a/src/llama_cloud/lib/index/retriever.py
+++ b/src/llama_cloud/lib/index/retriever.py
@@ -136,7 +136,7 @@ class LlamaCloudRetriever(BaseRetriever):
     ) -> List[NodeWithScore]:
         nodes: List[NodeWithScore] = []
         for res in result_nodes:
-            text_node = TextNode.model_validate(res.node.model_dump())
+            text_node = TextNode.model_validate(res.node.model_dump(exclude_none=True))
             text_node.metadata.update(metadata or {})
             nodes.append(NodeWithScore(node=text_node, score=res.score))
 


### PR DESCRIPTION
## Bug Fix

During testing, I found the TextNode validation between LlamaCloud and LlamaIndex packages to be buggy. 

## GitHub Issues

closes https://github.com/run-llama/llama-cloud-py/issues/50

## Core Changes

- [x] set `ignore_none=True` for cross package model validation

## Other Changes

- [x] suggested doc and .gitignore updates