### PR TITLE
fix: use agentic parse for citation bounding box demo

### DIFF
--- a/examples/extract/extract_v2_complete_walkthrough.ipynb
+++ b/examples/extract/extract_v2_complete_walkthrough.ipynb
@@ -386,7 +386,7 @@
     "        \"data_schema\": citation_schema,\n",
     "        \"extraction_target\": \"per_doc\",\n",
     "        \"tier\": \"cost_effective\",\n",
-    "        \"cite_sources\": True,\n",
+    "        \"cite_sources\": True,\n        \"parse_tier\": \"agentic\",  # agentic parse produces tighter bounding boxes\n",
     "    },\n",
     "    verbose=True,\n",
     ")\n",


### PR DESCRIPTION
## Summary

Add `"parse_tier": "agentic"` to the citation/bounding box demo section of the cookbook. One-line change.

## Why

Testing all 4 tier combinations showed that `cost_effective` parse produces broken bounding boxes on 3 of 7 fields. Agentic parse fixes all of them. The parse tier is what matters, not the extract tier.

| Field | CE parse bbox | Agentic parse bbox |
|---|---|---|
| filing_date | 363x331 (42% of page) | 118x10 (tight) |
| primary_examiner | empty array | 210x20 (correct) |
| title | 216x28 (sometimes wrong location) | 193x18 (correct) |
| applicant | 213x9 | 214x10 |
| grant_date | 98x10 | 67x11 |
| num_claims | 112x8 | 113x9 |

Keeps extraction on `cost_effective` tier (cheap) with `agentic` parse (better bounding boxes).

Related tickets: LI-6712, LI-6713, LI-6714

## Test plan
- [x] Tested all 4 tier combos on patent US10452978
- [x] Lint passes