### PR TITLE
Add Index V2 examples

### DIFF
--- a/examples/index_v2/agent_tools.py
+++ b/examples/index_v2/agent_tools.py
@@ -1,3 +1,5 @@
+# ! pip install llama-cloud openai-agents
+
 from __future__ import annotations
 
 import os

--- a/examples/index_v2/agent_tools.py
+++ b/examples/index_v2/agent_tools.py
@@ -6,8 +6,10 @@ import asyncio
 from typing import cast
 
 from agents import Agent, Runner, function_tool
-from agents.items import ToolCallItem, FunctionCallOutput, ToolCallOutputItem, ResponseFunctionToolCall
-from agents.models.chatcmpl_stream_handler import ResponseTextDeltaEvent
+from agents.items import ToolCallItem, ToolCallOutputItem
+from openai.types.responses.response_input_item_param import FunctionCallOutput
+from openai.types.responses.response_text_delta_event import ResponseTextDeltaEvent
+from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
 
 from llama_cloud import AsyncLlamaCloud
 from llama_cloud._utils import lru_cache

--- a/examples/index_v2/agent_tools.py
+++ b/examples/index_v2/agent_tools.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import os
+import json
+import asyncio
+from typing import cast
+
+from agents import Agent, Runner, function_tool
+from agents.items import ToolCallItem, FunctionCallOutput, ToolCallOutputItem, ResponseFunctionToolCall
+from agents.models.chatcmpl_stream_handler import ResponseTextDeltaEvent
+
+from llama_cloud import AsyncLlamaCloud
+from llama_cloud._utils import lru_cache
+from llama_cloud.types.beta.retrieval_retrieve_params import Rerank
+
+
+@lru_cache(maxsize=1)
+def get_client() -> AsyncLlamaCloud:
+    return AsyncLlamaCloud(
+        api_key=os.getenv("LLAMA_CLOUD_API_KEY") or os.getenv("LLAMA_PARSE_API_KEY"),
+        base_url=os.getenv("LLAMA_CLOUD_BASE_URL") or os.getenv("LLAMA_PARSE_BASE_URL"),
+    )
+
+
+@lru_cache(maxsize=1)
+def get_project_id() -> str | None:
+    return os.getenv("LLAMA_CLOUD_PROJECT_ID") or os.getenv("LLAMA_PARSE_PROJECT_ID")
+
+
+@function_tool
+async def list_indexes() -> str:
+    """List all available indexes in the current project.
+
+    Returns a formatted string of index names and their export config IDs,
+    paginating through all results automatically.
+    """
+    client = get_client()
+    page_token = None
+    indexes: list[tuple[str, str]] = []
+    while True:
+        response = await client.beta.indexes.list(page_token=page_token, project_id=get_project_id())
+        indexes.extend([(i.name, i.export_config_id) for i in response.items])
+        if response.next_page_token is None:
+            break
+        page_token = response.next_page_token
+    ls = "\n".join([f"- {i[0]} (ID: {i[1]})" for i in indexes])
+    return f"Available indexes:\n{ls}"
+
+
+@function_tool
+async def retrieve(
+    index_id: str, query: str, top_k: int | None, score_threshold: float | None, rerank_top_n: int | None
+) -> str:
+    """Run a semantic retrieval query against an index.
+
+    Args:
+        index_id: The index to query.
+        query: The search query string.
+        top_k: Maximum number of results to return. If None, uses the server default.
+        score_threshold: Minimum relevance score for results to be included. If None, no threshold is applied.
+        rerank_top_n: If set, enables reranking and returns the top N reranked results.
+
+    Returns a formatted string of results with scores, content previews, and metadata.
+    """
+    client = get_client()
+    response = await client.beta.retrieval.retrieve(
+        index_id=index_id,
+        query=query,
+        top_k=top_k,
+        score_threshold=score_threshold,
+        rerank=Rerank(enabled=rerank_top_n is not None, top_n=rerank_top_n),
+    )
+    retrieved: list[str] = []
+    for i, result in enumerate(response.results):
+        r = f"Retrieval result #{i + 1} (Score: {result.score or 'NA'})\n{result.content[:200]}\n"
+        if result.metadata:
+            r += f"Metadata:\n\n```json\n{json.dumps(result.metadata, indent=2)}\n"
+        r += "\n\n---\n\n"
+        retrieved.append(r)
+    return "\n\n".join(retrieved)
+
+
+@function_tool
+async def find_files(index_id: str, file_name: str | None, file_name_contains: str | None) -> str:
+    """Search for files within an index by name.
+
+    Args:
+        index_id: The index to search within.
+        file_name: Exact file name to match. If None, not used as a filter.
+        file_name_contains: Substring to match against file names. If None, not used as a filter.
+
+    Returns a formatted string listing matching file names and their IDs,
+    paginating through all results automatically.
+    """
+    client = get_client()
+    files: list[tuple[str, str]] = []
+    page_token = None
+    while True:
+        response = await client.beta.retrieval.find(
+            index_id=index_id, file_name=file_name, file_name_contains=file_name_contains, page_token=page_token
+        )
+        files.extend([(f.file_name, f.file_id) for f in response.items])
+        if response.next_page_token is None:
+            break
+        page_token = response.next_page_token
+    ls = "\n".join([f"- {i[0]} (ID: {i[1]})" for i in files])
+    return f"Files matching the query:\n{ls}"
+
+
+@function_tool
+async def read_file(index_id: str, file_id: str, offset: int | None, max_length: int | None) -> str:
+    """Read the contents of a file from an index.
+
+    Args:
+        index_id: The index the file belongs to.
+        file_id: The ID of the file to read.
+        offset: Character offset to start reading from. Defaults to 0 if None.
+        max_length: Maximum number of characters to return. If None, uses the server default.
+
+    Returns the raw file content as a string.
+    """
+    client = get_client()
+    response = await client.beta.retrieval.read(
+        index_id=index_id, file_id=file_id, offset=offset or 0, max_length=max_length
+    )
+    return response.content
+
+
+@function_tool
+async def grep_file(index_id: str, file_id: str, pattern: str, context_chars: int | None, limit: int | None) -> str:
+    """Search for a pattern within a specific file using grep.
+
+    Args:
+        index_id: The index the file belongs to.
+        file_id: The ID of the file to search.
+        pattern: The pattern to search for.
+        context_chars: Number of surrounding characters to include with each match. If None, uses the server default.
+        limit: Maximum number of matches to return per page. If None, uses the server default.
+
+    Returns a formatted string of matches with their character positions,
+    paginating through all results automatically.
+    """
+    client = get_client()
+    matches: list[tuple[str, int, int]] = []
+    page_token = None
+    while True:
+        response = await client.beta.retrieval.grep(
+            index_id=index_id,
+            file_id=file_id,
+            pattern=pattern,
+            context_chars=context_chars,
+            page_size=limit,
+            page_token=page_token,
+        )
+        matches.extend([(m.content, m.start_char, m.end_char) for m in response.items])
+        if response.next_page_token is None:
+            break
+        page_token = response.next_page_token
+    ls = "\n".join([f"- {m[0]} (start: {m[1]}, end: {m[2]})" for m in matches])
+    return f"Grep matches:\n{ls}"
+
+
+async def run_agent() -> None:
+    agent = Agent(
+        name="Index V2 Agent",
+        tools=[list_indexes, find_files, retrieve, read_file, grep_file],
+        instructions="",
+        model="gpt-5.1",
+    )
+    runner = Runner.run_streamed(
+        agent,
+        input="List all the files available to you, read one and then search across all of them for 'blue cheese'",
+    )
+    async for event in runner.stream_events():
+        if event.type == "raw_response_event" and isinstance(event.data, ResponseTextDeltaEvent):
+            print(event.data.delta, end="", flush=True)
+        elif event.type == "run_item_stream_event" and isinstance(event.item, ToolCallItem):
+            print(
+                f"\nCalling tool: {cast(ResponseFunctionToolCall, event.item.raw_item).name} with input: {cast(ResponseFunctionToolCall, event.item.raw_item).arguments} (ID: {cast(ResponseFunctionToolCall, event.item.raw_item).call_id})"
+            )
+        elif event.type == "run_item_stream_event" and isinstance(event.item, ToolCallOutputItem):
+            print(
+                f"\nResult for tool call {cast(FunctionCallOutput, event.item.raw_item)['call_id']}:\n{event.item.output}"
+            )
+
+
+def main() -> None:
+    asyncio.run(run_agent())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/index_v2/create_sync_and_retrieve.py
+++ b/examples/index_v2/create_sync_and_retrieve.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import os
+import json
+import asyncio
+from typing import Any, Mapping
+
+from llama_cloud import AsyncLlamaCloud
+from llama_cloud._utils import lru_cache
+from llama_cloud.types.beta.retrieval_retrieve_params import Rerank
+
+MAX_POLLING_ATTEMPTS = 900
+POLLING_INTERVAL = 2
+
+
+def _get_status(metadata: Any) -> str:
+    """Safely extract the `status` field from index/directory metadata."""
+    if not metadata:
+        return "unknown"
+    if isinstance(metadata, Mapping):
+        return str(metadata.get("status", "unknown"))  # type: ignore
+    return str(getattr(metadata, "status", "unknown"))
+
+
+@lru_cache(maxsize=1)
+def get_client() -> AsyncLlamaCloud:
+    return AsyncLlamaCloud(
+        api_key=os.getenv("LLAMA_CLOUD_API_KEY") or os.getenv("LLAMA_PARSE_API_KEY"),
+        base_url=os.getenv("LLAMA_CLOUD_BASE_URL") or os.getenv("LLAMA_PARSE_BASE_URL"),
+    )
+
+
+@lru_cache(maxsize=1)
+def get_project_id() -> str | None:
+    return os.getenv("LLAMA_CLOUD_PROJECT_ID") or os.getenv("LLAMA_PARSE_PROJECT_ID")
+
+
+async def create_index_from_directory() -> tuple[str, str]:
+    client = get_client()
+    directory = os.getenv("DATA_DIR", "data/")
+    cloud_dir = await client.beta.directories.create(
+        name=os.getenv("DIR_NAME", "index-v2-demo"),
+        project_id=get_project_id(),
+        description="Directory containing some data as a demo for Index V2 usage",
+    )
+    print(f"Created a directory on the LlamaParse platform with ID: {cloud_dir.id}")
+
+    semaphore = asyncio.Semaphore(4)
+
+    async def upload_file_to_dir(file: str) -> str:
+        async with semaphore:
+            fl_obj = await client.beta.directories.files.upload(
+                directory_id=cloud_dir.id,
+                upload_file=file,
+                project_id=get_project_id(),
+            )
+            return fl_obj.id
+
+    file_ids = await asyncio.gather(
+        *[
+            upload_file_to_dir(os.path.join(directory, f))
+            for f in os.listdir(directory)
+            if os.path.isfile(os.path.join(directory, f))
+        ]
+    )
+
+    print(
+        f"Uploaded {len(file_ids)} files in {directory} to the directory on the LlamaParse Platform, with the following IDs: {', '.join(file_ids)}"
+    )
+
+    idx = await client.beta.indexes.create(
+        source_directory_id=cloud_dir.id, project_id=get_project_id(), name=os.getenv("INDEX_NAME", "index-v2-demo")
+    )
+
+    print(f"Created an index on the LlamaParse Platform with ID: {idx.id} and export config ID: {idx.export_config_id}")
+
+    return idx.id, idx.export_config_id
+
+
+async def sync_and_wait(index_id: str) -> None:
+    client = get_client()
+
+    await client.beta.indexes.sync(index_id=index_id)
+    attempts = 0
+    while attempts < MAX_POLLING_ATTEMPTS:
+        idx = await client.beta.indexes.get(index_id=index_id)
+        status = _get_status(idx.metadata)
+        if status == "ready":
+            return
+        elif status == "failed":
+            raise RuntimeError("Index sync failed")
+        attempts += 1
+        await asyncio.sleep(POLLING_INTERVAL)
+
+
+async def retrieve(export_config_id: str) -> None:
+    client = get_client()
+    retrieved = await client.beta.retrieval.retrieve(
+        index_id=export_config_id,
+        query=os.getenv("INDEX_RETRIEVAL_QUERY", "What information is available for retrieval?"),
+        top_k=10,
+        score_threshold=0.5,
+        rerank=Rerank(enabled=True, top_n=5),
+    )
+    for i, r in enumerate(retrieved.results):
+        print(f"Retrieved chunk #{i + 1} (Score: {r.score or 'no score'})")
+        print("Content:")
+        print(r.content)
+        print()
+        if r.metadata is not None:
+            print("Metadata")
+            print(json.dumps(r.metadata, indent=2))
+        print()
+        print("#########################################")
+        print()
+
+
+async def run() -> None:
+    index_id, export_config_id = await create_index_from_directory()
+    await sync_and_wait(index_id)
+    await retrieve(export_config_id)
+
+
+def main() -> None:
+    asyncio.run(run())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ show_error_codes = true
 #
 # We also exclude our `tests` as mypy doesn't always infer
 # types correctly and Pyright will still catch any type errors.
-exclude = ["src/llama_cloud/_files.py", "_dev/.*.py", "tests/.*"]
+exclude = ["src/llama_cloud/_files.py", "_dev/.*.py", "tests/.*", "examples/index_v2/agent_tools.py"]
 
 strict_equality = true
 implicit_reexport = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ exclude = [
     ".venv",
     ".nox",
     ".git",
+    "examples/index_v2/agent_tools.py",
 ]
 
 reportImplicitOverride = true


### PR DESCRIPTION
Adds two example scripts demonstrating Index V2 usage:

- `examples/index_v2/agent_tools.py` — Agent tool integration with list_indexes, retrieve, find_files, read_file, and grep_file tools.
- `examples/index_v2/create_sync_and_retrieve.py` — End-to-end flow for creating an index from a local directory, syncing it, and running retrieval.