### PR TITLE
ci: mint release-please token from CI_BOT app instead of a PAT

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate release token (CI_BOT GitHub App)
+        id: rp-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CI_BOT_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.rp-token.outputs.token }}


### PR DESCRIPTION
Retires the `RELEASE_PLEASE_TOKEN` personal PAT, replacing it with a scoped **llama-org-ci-bot** (org-owned) GitHub App token. App tokens trigger downstream workflows (the default `GITHUB_TOKEN` does not), so the release flow is preserved. Part of removing personal PATs from the SDK pipeline.