### PR TITLE
ci: mint release-doctor token from CI_BOT app instead of a PAT

### DIFF
--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -14,9 +14,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Generate release token (CI_BOT GitHub App)
+        id: rp-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CI_BOT_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
+          permission-contents: read
+
       - name: Check release environment
         run: |
           bash ./bin/check-release-environment
         env:
-          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          RELEASE_PLEASE_TOKEN: ${{ steps.rp-token.outputs.token }}
           PYPI_TOKEN: ${{ secrets.LLAMA_CLOUD_PYPI_TOKEN || secrets.PYPI_TOKEN }}


### PR DESCRIPTION
The Release Doctor fails on release PRs because `bin/check-release-environment` still requires the `RELEASE_PLEASE_TOKEN` secret, which was retired in favor of a CI_BOT app token minted at runtime.

The script only checks that the value is non-empty — it never uses the token — so this mints the CI_BOT app token (identical to `release-please.yml`) and feeds it in. The doctor passes; nothing else changes. Publishing is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)